### PR TITLE
Fix footer github link

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -13,7 +13,7 @@
     </div>
   
   <footer>
-  <p class="footer"> Made with <i class="fa fa-heart" aria-hidden="true"></i> and lives on <a href"https://github.com/WeSpeakToo" target="_blank">Github</a>. Contact <a href="https://twitter.com/DataLensDC" target="_blank">Kate</a> <a href="mailto:datalensdc@gmail.com" target="_blank"> with questions or feedback. <br>
+  <p class="footer"> Made with <i class="fa fa-heart" aria-hidden="true"></i> and lives on <a href="https://github.com/WeSpeakToo" target="_blank">Github</a>. Contact <a href="https://twitter.com/DataLensDC" target="_blank">Kate</a> <a href="mailto:datalensdc@gmail.com" target="_blank"> with questions or feedback. <br>
   Photo courtesy <a href="http://www.wocintechchat.com/" target="_blank">#WOCInTechChat</a></p>
   </footer>
   </body>


### PR DESCRIPTION
The footer github link was broken due to a missing equals sign; this commit should fix it (but I haven't built the site/tested).